### PR TITLE
[Bugfix] Comparison issue when facing with inverted (negated) rule that have whole field with specific action

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A core package for managing the authorization through CanCanCan style. With supports of granularity based on Attributes Based Access Control.",
     "type": "library",
     "license": "MIT",
-    "version": "0.6.0-stable",
+    "version": "0.6.1-stable",
     "scripts": {
         "test": "./vendor/bin/pest"
     },

--- a/src/Abilities/Core/Comparator/AbilityCheckerImpl.php
+++ b/src/Abilities/Core/Comparator/AbilityCheckerImpl.php
@@ -24,7 +24,10 @@ class AbilityCheckerImpl implements AbilityChecker
         $starActionRules = [];
         foreach ($unspecifiedActionRules as $unspecifiedActionRule) {
             /** 1. Checking on specific inverted rules */
-            if ($unspecifiedActionRule->isInverted() && $unspecifiedActionRule->getResource()->matchField($field)) {
+            if ($unspecifiedActionRule->isInverted() &&
+                $unspecifiedActionRule->getResource()->matchField($field) &&
+                $unspecifiedActionRule->getAction()->match($action)
+            ) {
                 return false; // as the correspondent user is prohibited access resource
             } elseif ($unspecifiedActionRule->getAction()->wholeAction()) {
                 $starActionRules[] = $unspecifiedActionRule;

--- a/src/Abilities/Core/Objects/Action.php
+++ b/src/Abilities/Core/Objects/Action.php
@@ -37,4 +37,13 @@ class Action
     {
         return $this->get();
     }
+
+    public function match(string $action): bool
+    {
+        if ($this->wholeAction()) {
+            return true;
+        }
+
+        return $this->get() === $action;
+    }
 }

--- a/tests/Feature/Core/AbilityCheckerImplTest.php
+++ b/tests/Feature/Core/AbilityCheckerImplTest.php
@@ -189,6 +189,8 @@ describe('can() feature function test', function () {
             ->toBeFalse();
         expect($abilityChecker->can('review', 'resource1', 'scope1'))
             ->toBeFalse();
+        expect($abilityChecker->can('review', 'resource1', 'scope1', (object) ['author' => 666]))
+            ->toBeFalse();
     });
 });
 

--- a/tests/Feature/Core/AbilityCheckerImplTest.php
+++ b/tests/Feature/Core/AbilityCheckerImplTest.php
@@ -157,6 +157,35 @@ describe('can() feature function test', function () {
         expect($abilityChecker->can('update', 'resource1', 'scope1', (object) ['author' => 666]))
             ->toBeFalse();
     });
+
+    it('must return true when has inverted specific action with whole field but has other specific field with whole action', function () {
+        $compiledRules = new CompiledRules([
+            (object) [
+                'id' => 1,
+                'rule' => 'scope2:resource1:read'
+            ],
+            (object) [
+                'id' => 2,
+                'rule' => '!scope1:resource1/*:review'
+            ],
+            (object) [
+                'id' => 3,
+                'rule' => 'scope1:resource1/{"author": 667}:*'
+            ],
+            (object) [
+                'id' => 4,
+                'rule' => 'scope2:resource1/[6, 7, 8]:update'
+            ],
+        ]);
+
+        $abilityChecker = new AbilityCheckerImpl($compiledRules);
+        expect($abilityChecker->can('update', 'resource1', 'scope1', (object) ['author' => 667]))
+            ->toBeTrue();
+        expect($abilityChecker->can('review', 'resource1', 'scope1', (object) ['author' => 667]))
+            ->toBeFalse();
+        expect($abilityChecker->can('review', 'resource1', 'scope1'))
+            ->toBeFalse();
+    });
 });
 
 describe('cannot() feature function test', function () {

--- a/tests/Feature/Core/AbilityCheckerImplTest.php
+++ b/tests/Feature/Core/AbilityCheckerImplTest.php
@@ -161,21 +161,13 @@ describe('can() feature function test', function () {
     it('must return as expected when has inverted specific action and whole field rule compared with rule that has specific field with whole action', function () {
         $compiledRules = new CompiledRules([
             (object) [
-                'id' => 1,
-                'rule' => 'scope2:resource1:read'
-            ],
-            (object) [
                 'id' => 2,
                 'rule' => '!scope1:resource1/*:review'
             ],
             (object) [
                 'id' => 3,
                 'rule' => 'scope1:resource1/{"author": 667}:*'
-            ],
-            (object) [
-                'id' => 4,
-                'rule' => 'scope2:resource1/[6, 7, 8]:update'
-            ],
+            ]
         ]);
 
         $abilityChecker = new AbilityCheckerImpl($compiledRules);

--- a/tests/Feature/Core/AbilityCheckerImplTest.php
+++ b/tests/Feature/Core/AbilityCheckerImplTest.php
@@ -158,7 +158,7 @@ describe('can() feature function test', function () {
             ->toBeFalse();
     });
 
-    it('must return true when has inverted specific action with whole field but has other specific field with whole action', function () {
+    it('must return as expected when has inverted specific action and whole field rule compared with rule that has specific field with whole action', function () {
         $compiledRules = new CompiledRules([
             (object) [
                 'id' => 1,

--- a/tests/Feature/Core/AbilityCheckerImplTest.php
+++ b/tests/Feature/Core/AbilityCheckerImplTest.php
@@ -181,6 +181,10 @@ describe('can() feature function test', function () {
         $abilityChecker = new AbilityCheckerImpl($compiledRules);
         expect($abilityChecker->can('update', 'resource1', 'scope1', (object) ['author' => 667]))
             ->toBeTrue();
+        expect($abilityChecker->can('update', 'resource1', 'scope1'))
+            ->toBeFalse();
+        expect($abilityChecker->can('*', 'resource1', 'scope1'))
+            ->toBeFalse();
         expect($abilityChecker->can('review', 'resource1', 'scope1', (object) ['author' => 667]))
             ->toBeFalse();
         expect($abilityChecker->can('review', 'resource1', 'scope1'))

--- a/tests/Unit/Core/Objects/ActionTest.php
+++ b/tests/Unit/Core/Objects/ActionTest.php
@@ -35,3 +35,22 @@ it('can know if the action is whole action (star)', function () {
     expect((new Action('*'))->wholeAction())->toBeTrue();
 
 });
+
+describe('match() function test', function () {
+   it('must return true when the current action is whole action', function () {
+       $currentAction = new Action();
+
+       expect($currentAction->match('create'))->toBeTrue();
+       expect($currentAction->match('*'))->toBeTrue();
+   });
+
+   it ('must return true when the match with specific action', function () {
+       $currentAction = new Action('create');
+       expect($currentAction->match('create'))->toBeTrue();
+   });
+
+   it('must return false when not match with specific action', function () {
+       $currentAction = new Action('create');
+       expect($currentAction->match('update'))->toBeFalse();
+   });
+});


### PR DESCRIPTION
## About

This PR will fix a bug when checking the user abilities.

Example: 
User A have a list of these rules : 
```
!scope:resourceA/*:review
scope:resourceA/{"author": 'A'}:*
``` 
This rules means that the User A : 
1. Cannot do `review` on all field of `resourceA`
2. Can do anything (except `review`) on `resourceA` authored by User A (specific author field)

**Current Condition** 
The engine will return false when User A want to check his/her capability for doing create, update, or anything (except `review`) on `resourceA`. So, it's contradict with the behavior of the engine.

**Expected Condition**
The engine must return true as the User A have anything capabilities on resource `resourceA` with his/her as author (identified by specific field)
